### PR TITLE
feat: add set-state command to edit React hook state

### DIFF
--- a/daemon/src/actions.ts
+++ b/daemon/src/actions.ts
@@ -27,6 +27,7 @@ import type {
   ReactDetectCommand,
   ComponentsCommand,
   HooksCommand,
+  SetStateCommand,
   CookiesGetCommand,
   CookiesSetCommand,
   StorageGetCommand,
@@ -49,6 +50,12 @@ const COMPONENT_TREE_SCRIPT = readFileSync(
 /** Cached hook extraction script content, loaded once at module init. */
 const HOOKS_SCRIPT = readFileSync(
   fileURLToPath(new URL('./scripts/get-hooks.js', import.meta.url)),
+  'utf-8'
+);
+
+/** Cached set-state script content, loaded once at module init. */
+const SET_STATE_SCRIPT = readFileSync(
+  fileURLToPath(new URL('./scripts/set-state.js', import.meta.url)),
   'utf-8'
 );
 
@@ -118,6 +125,8 @@ export async function executeCommand(command: Command, browser: BrowserManager):
         return await handleComponents(command, browser);
       case 'hooks':
         return await handleHooks(command, browser);
+      case 'set-state':
+        return await handleSetState(command, browser);
       case 'cookies_get':
         return await handleCookiesGet(command, browser);
       case 'cookies_set':
@@ -536,6 +545,25 @@ async function handleHooks(
 
   const result = await page.evaluate(
     `(${HOOKS_SCRIPT})(${JSON.stringify(options)})`
+  );
+
+  return successResponse(command.id, result);
+}
+
+async function handleSetState(
+  command: SetStateCommand,
+  browser: BrowserManager
+): Promise<Response> {
+  const page = browser.getPage();
+
+  const options = {
+    component: command.component,
+    hookIndex: command.hookIndex,
+    value: command.value,
+  };
+
+  const result = await page.evaluate(
+    `(${SET_STATE_SCRIPT})(${JSON.stringify(options)})`
   );
 
   return successResponse(command.id, result);

--- a/daemon/src/protocol.ts
+++ b/daemon/src/protocol.ts
@@ -190,6 +190,13 @@ const hooksSchema = baseCommandSchema.extend({
   compact: z.boolean().optional(),
 });
 
+const setStateSchema = baseCommandSchema.extend({
+  action: z.literal('set-state'),
+  component: z.string().min(1),
+  hookIndex: z.number().int().nonnegative(),
+  value: z.unknown(),
+});
+
 const cookiesGetSchema = baseCommandSchema.extend({
   action: z.literal('cookies_get'),
   urls: z.array(z.string()).optional(),
@@ -275,6 +282,7 @@ const commandSchema = z.discriminatedUnion('action', [
   reactDetectSchema,
   componentsSchema,
   hooksSchema,
+  setStateSchema,
   cookiesGetSchema,
   cookiesSetSchema,
   cookiesClearSchema,

--- a/daemon/src/scripts/set-state.js
+++ b/daemon/src/scripts/set-state.js
@@ -1,0 +1,154 @@
+// Set React hook state for a component by hook index.
+// Uses the renderer's overrideHookState API (same mechanism as React DevTools).
+// Evaluated in page context via Playwright's page.evaluate().
+
+(function (options) {
+  var componentName = options && options.component;
+  var hookIndex = options && options.hookIndex;
+  var newValue = options && options.value;
+
+  if (!componentName) {
+    return { error: 'No component name provided' };
+  }
+  if (typeof hookIndex !== 'number' || hookIndex < 0) {
+    return { error: 'Invalid hook index: must be a non-negative integer' };
+  }
+
+  var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return { error: 'No React DevTools hook found' };
+  }
+
+  if (!hook._fiberRoots || hook._fiberRoots.size === 0) {
+    return { error: 'No React roots detected — page may not use React or has not rendered yet' };
+  }
+
+  // Fiber tag constants
+  var FunctionComponent = 0;
+  var ClassComponent = 1;
+  var ForwardRef = 11;
+  var MemoComponent = 14;
+  var SimpleMemoComponent = 15;
+
+  function getComponentName(fiber) {
+    if (!fiber.type) return null;
+    if (typeof fiber.type === 'string') return fiber.type;
+    if (fiber.type.displayName) return fiber.type.displayName;
+    if (fiber.type.name) return fiber.type.name;
+    if (fiber.type.render) {
+      return fiber.type.render.displayName || fiber.type.render.name || 'ForwardRef';
+    }
+    if (fiber.type.type) {
+      return fiber.type.type.displayName || fiber.type.type.name || 'Memo';
+    }
+    return 'Anonymous';
+  }
+
+  function isComponent(fiber) {
+    return (
+      fiber.tag === FunctionComponent ||
+      fiber.tag === ClassComponent ||
+      fiber.tag === ForwardRef ||
+      fiber.tag === MemoComponent ||
+      fiber.tag === SimpleMemoComponent
+    );
+  }
+
+  function findComponent(fiber) {
+    if (!fiber) return null;
+    var current = fiber;
+    while (current) {
+      if (isComponent(current)) {
+        var name = getComponentName(current);
+        if (name && name.toLowerCase().indexOf(componentName.toLowerCase()) !== -1) {
+          return current;
+        }
+      }
+      if (current.child) {
+        var found = findComponent(current.child);
+        if (found) return found;
+      }
+      current = current.sibling;
+    }
+    return null;
+  }
+
+  // Find the target fiber and which renderer owns it
+  var targetFiber = null;
+  var targetRendererID = null;
+
+  hook._fiberRoots.forEach(function (fiberRootSet, rendererID) {
+    if (targetFiber) return;
+    fiberRootSet.forEach(function (fiberRoot) {
+      if (targetFiber) return;
+      if (fiberRoot.current) {
+        var found = findComponent(fiberRoot.current);
+        if (found) {
+          targetFiber = found;
+          targetRendererID = rendererID;
+        }
+      }
+    });
+  });
+
+  if (!targetFiber) {
+    return { error: 'Component not found: ' + componentName };
+  }
+
+  if (targetFiber.tag === ClassComponent) {
+    return { error: 'set-state is not supported for class components — use evaluate instead' };
+  }
+
+  // Validate the hook index exists and is a state/reducer hook
+  var hookNode = targetFiber.memoizedState;
+  var currentIndex = 0;
+  while (hookNode && currentIndex < hookIndex) {
+    hookNode = hookNode.next;
+    currentIndex++;
+  }
+
+  if (!hookNode) {
+    return { error: 'Hook index ' + hookIndex + ' out of range (component has ' + currentIndex + ' hooks)' };
+  }
+
+  // Check that this is a state or reducer hook (has a queue)
+  if (hookNode.queue === null || hookNode.queue === undefined) {
+    return { error: 'Hook at index ' + hookIndex + ' is not a useState/useReducer hook — only state hooks can be set' };
+  }
+
+  // Try renderer.overrideHookState first (React 16.8+)
+  var renderer = hook.renderers.get(targetRendererID);
+  if (renderer && typeof renderer.overrideHookState === 'function') {
+    try {
+      // path=[] means replace the entire value
+      renderer.overrideHookState(targetFiber, '' + hookIndex, [], newValue);
+      return {
+        component: getComponentName(targetFiber),
+        hookIndex: hookIndex,
+        success: true,
+        method: 'overrideHookState',
+      };
+    } catch (e) {
+      return { error: 'overrideHookState failed: ' + (e && e.message ? e.message : String(e)) };
+    }
+  }
+
+  // Fallback: directly mutate and trigger update via setState dispatcher
+  // This works when the renderer doesn't expose overrideHookState (e.g., production builds)
+  try {
+    var queue = hookNode.queue;
+    if (queue && typeof queue.dispatch === 'function') {
+      queue.dispatch(newValue);
+      return {
+        component: getComponentName(targetFiber),
+        hookIndex: hookIndex,
+        success: true,
+        method: 'dispatch',
+      };
+    }
+
+    return { error: 'No dispatch function found on hook queue — state update not possible' };
+  } catch (e) {
+    return { error: 'State update failed: ' + (e && e.message ? e.message : String(e)) };
+  }
+})

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -182,6 +182,13 @@ export interface HooksCommand extends BaseCommand {
   compact?: boolean;
 }
 
+export interface SetStateCommand extends BaseCommand {
+  action: 'set-state';
+  component: string;
+  hookIndex: number;
+  value: unknown;
+}
+
 export interface CookiesGetCommand extends BaseCommand {
   action: 'cookies_get';
   urls?: string[];
@@ -265,6 +272,7 @@ export type Command =
   | ReactDetectCommand
   | ComponentsCommand
   | HooksCommand
+  | SetStateCommand
   | CookiesGetCommand
   | CookiesSetCommand
   | CookiesClearCommand

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -3,9 +3,9 @@ name: debug-browser
 description: >
   Debug React applications via headless browser with rich introspection.
   Trigger when the user asks to: debug React app, inspect React components,
-  check component state, view hook values, capture console errors,
-  debug React rendering, inspect fiber tree, examine React props,
-  trace React re-renders, or diagnose React application issues.
+  check component state, view hook values, set React state, modify hook state,
+  capture console errors, debug React rendering, inspect fiber tree,
+  examine React props, trace React re-renders, or diagnose React application issues.
 ---
 
 # debug-browser
@@ -123,6 +123,36 @@ debug-browser hooks DataGrid --depth 5
 
 The default serialization depth is 3. Increase it when inspecting components with deeply nested state objects or context values.
 
+### Set Hook State
+
+Directly modify a component's `useState` or `useReducer` value without interacting with the UI. This enables rapid hypothesis testing — inspect the current state, form a theory about a bug, and immediately test it by forcing a specific state value.
+
+```bash
+debug-browser set-state Counter 0 42
+debug-browser set-state TodoList 1 '["item1","item2"]'
+debug-browser set-state Settings 0 '{"theme":"dark","lang":"en"}'
+```
+
+The first argument is the component name (same substring match as `hooks`), the second is the hook index (as shown in `hooks` output), and the third is the new value as JSON.
+
+Use `hooks` first to identify the hook index, then `set-state` to modify it:
+
+```bash
+# 1. Inspect current state
+debug-browser hooks Counter
+#   [0] useState: 5
+#   [1] useEffect: deps=[5] cleanup=no
+
+# 2. Set state to a boundary value
+debug-browser set-state Counter 0 -1
+
+# 3. Re-inspect to confirm and check for errors
+debug-browser hooks Counter
+debug-browser console errors
+```
+
+Only `useState` and `useReducer` hooks can be set. Attempting to set an effect, ref, or memo hook returns an error. The state update triggers a normal React re-render, so all derived state, effects, and child components update as expected.
+
 ### Check Console Output
 
 Console messages accumulate in an inbox between commands. Retrieve them at any time:
@@ -230,7 +260,7 @@ For reliable results, follow this sequence when diagnosing an issue:
 3. `console clear` to reset the inbox
 4. `components --component <Name>` to find the relevant component
 5. `hooks <Name>` to inspect its state
-6. Perform the interaction (`click` / `type`) that triggers the bug
+6. Perform the interaction (`click` / `type`) that triggers the bug — or use `set-state` to force a specific state value for hypothesis testing
 7. Re-inspect `hooks` and `console errors` to observe what changed
 
 ## Command Reference

--- a/skill/references/commands.md
+++ b/skill/references/commands.md
@@ -8,6 +8,7 @@
 | `react detect` | Check if React is present on the page | |
 | `components` | List React component tree | `--depth`, `--component`, `--no-props`, `--no-state`, `--compact` |
 | `hooks <component>` | Inspect hooks for a named component | `--depth`, `--compact` |
+| `set-state <component> <index> <value>` | Set a useState/useReducer hook's value | |
 | `console logs` | Show collected console.log messages | |
 | `console errors` | Show collected errors and exceptions | |
 | `console clear` | Clear the console inbox | |
@@ -214,6 +215,63 @@ debug-browser hooks Counter --compact
 - For class components, returns `classState` instead of hooks array.
 - Each hook has a stable index (`[0]`, `[1]`, etc.) for tracking values across repeated inspections.
 - If multiple components match the name, the first match is inspected.
+
+---
+
+## set-state
+
+**Syntax:**
+
+```
+debug-browser set-state <component> <hook-index> <value>
+```
+
+**Purpose:** Set the value of a `useState` or `useReducer` hook, triggering a React re-render. Enables testing edge cases and reproducing bugs by forcing specific state values without UI interaction.
+
+**Arguments:**
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `component` | `string` | yes | Component name (same substring match as `hooks`). |
+| `hook-index` | `u32` | yes | Hook index (0-based, as shown in `hooks` output). |
+| `value` | `string` | yes | New value as JSON. Non-JSON strings are treated as string values. |
+
+**Output:**
+
+- **text:** Confirmation with component name and hook index. Example:
+  ```
+  State updated: Counter hook [0]
+  ```
+- **json:** `{ "success": true, "data": { "component": "Counter", "hookIndex": 0, "success": true, "method": "overrideHookState" } }`
+
+**Example:**
+
+```bash
+# Set a number
+debug-browser set-state Counter 0 42
+
+# Set an array
+debug-browser set-state TodoList 1 '["item1","item2"]'
+
+# Set an object
+debug-browser set-state Settings 0 '{"theme":"dark"}'
+
+# Set a string (quoted JSON)
+debug-browser set-state Greeting 0 '"hello"'
+
+# Set a boolean
+debug-browser set-state Toggle 0 false
+
+# Set null
+debug-browser set-state Form 0 null
+```
+
+**Notes:**
+- Only `useState` and `useReducer` hooks can be set. Other hook types (useEffect, useRef, useMemo, etc.) return an error.
+- The value argument is parsed as JSON. If JSON parsing fails, it is treated as a plain string.
+- The state update triggers a normal React re-render — effects, derived state, and child components update accordingly.
+- Uses React DevTools' `overrideHookState` API when available, with a fallback to the hook's dispatch function.
+- Use `hooks <component>` first to identify the correct hook index.
 
 ---
 

--- a/skill/references/workflows.md
+++ b/skill/references/workflows.md
@@ -133,7 +133,41 @@ debug-browser hooks SettingsForm
 debug-browser eval "document.querySelector('.success-toast')?.textContent"
 ```
 
-## Workflow 5: Attach to an Existing Dev Server
+## Workflow 5: Hypothesis Testing with set-state
+
+Test edge cases and reproduce bugs by forcing specific state values.
+
+```bash
+# 1. Navigate and inspect the component
+debug-browser navigate http://localhost:3000
+debug-browser hooks CartSummary
+#    [0] useState: [{"id":1,"qty":2},{"id":2,"qty":1}]
+#    [1] useState: false          # isLoading
+#    [2] useEffect: deps=[2] cleanup=no
+
+# 2. Hypothesis: "What happens with an empty cart?"
+debug-browser set-state CartSummary 0 '[]'
+debug-browser console errors
+#    Check if empty state causes a crash or shows a fallback UI
+
+# 3. Hypothesis: "What if qty is negative?"
+debug-browser set-state CartSummary 0 '[{"id":1,"qty":-1}]'
+debug-browser hooks CartSummary
+debug-browser console errors
+#    Check if negative quantity breaks total calculation
+
+# 4. Hypothesis: "What if loading gets stuck?"
+debug-browser set-state CartSummary 1 true
+debug-browser components --component CartSummary
+#    Check if the loading spinner renders correctly
+
+# 5. Reset to a known good state and verify recovery
+debug-browser set-state CartSummary 1 false
+debug-browser set-state CartSummary 0 '[{"id":1,"qty":2}]'
+debug-browser hooks CartSummary
+```
+
+## Workflow 6: Attach to an Existing Dev Server
 
 Debug a running Chrome instance instead of launching headless.
 

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -135,6 +135,17 @@ pub fn hooks(component: &str, depth: Option<u32>, compact: bool) -> Value {
     cmd
 }
 
+/// Set a React hook's state value by component name and hook index.
+pub fn set_state(component: &str, hook_index: u32, value: Value) -> Value {
+    json!({
+        "id": gen_id(),
+        "action": "set-state",
+        "component": component,
+        "hookIndex": hook_index,
+        "value": value,
+    })
+}
+
 /// Detect whether React is present on the current page.
 pub fn react_detect() -> Value {
     json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -90,6 +90,16 @@ enum Commands {
         #[arg(long)]
         compact: bool,
     },
+    /// Set a React hook's state value
+    SetState {
+        /// Component name (substring match)
+        component: String,
+        /// Hook index (0-based, as shown by `hooks` command)
+        #[arg(name = "hook-index")]
+        hook_index: u32,
+        /// New value (JSON)
+        value: String,
+    },
     /// Manage console logs/errors inbox
     Console {
         #[command(subcommand)]
@@ -242,6 +252,11 @@ fn build_command(command: &Commands) -> serde_json::Value {
             ..
         } => commands::components(*depth, *include_host, !no_props, !no_state, *props_depth, *compact),
         Commands::Hooks { component, depth, compact } => commands::hooks(component, *depth, *compact),
+        Commands::SetState { component, hook_index, value } => {
+            let parsed: serde_json::Value = serde_json::from_str(value)
+                .unwrap_or_else(|_| serde_json::Value::String(value.clone()));
+            commands::set_state(component, *hook_index, parsed)
+        }
         Commands::Console { action } => match action {
             ConsoleAction::Logs => commands::console_logs(),
             ConsoleAction::Errors => commands::console_errors(),
@@ -643,6 +658,22 @@ fn print_hooks(resp: &Response) {
                 println!("{}", line);
             }
         }
+    } else {
+        println!("No data returned.");
+    }
+}
+
+/// Print set-state response in human-readable format.
+fn print_set_state(resp: &Response) {
+    if let Some(ref data) = resp.data {
+        if let Some(err) = data.get("error").and_then(|v| v.as_str()) {
+            eprintln!("Error: {}", err);
+            return;
+        }
+
+        let component = data.get("component").and_then(|v| v.as_str()).unwrap_or("?");
+        let hook_index = data.get("hookIndex").and_then(|v| v.as_u64()).unwrap_or(0);
+        println!("State updated: {} hook [{}]", component, hook_index);
     } else {
         println!("No data returned.");
     }
@@ -1167,6 +1198,7 @@ fn main() -> Result<()> {
                         StateAction::Save { .. } => print_action_confirmation(&resp),
                         StateAction::Load => print_response(&resp, &cli.format),
                     },
+                    Commands::SetState { .. } => print_set_state(&resp),
                     Commands::Click { .. } | Commands::Type { .. } => print_action_confirmation(&resp),
                     Commands::Close => print_action_confirmation(&resp),
                 }


### PR DESCRIPTION
## Summary

Closes #1.

- Adds `set-state <component> <hook-index> <value>` command across the full stack (Rust CLI, daemon protocol, browser script)
- Uses React DevTools' `overrideHookState` API with `queue.dispatch()` fallback for production builds
- Only allows mutation of `useState`/`useReducer` hooks; other hook types return a clear error
- Value argument is parsed as JSON, falling back to plain string

## Skill updates

- Added `set-state` to SKILL.md methodology (between "Drill into Hook State" and "Check Console Output")
- Added full command reference in `references/commands.md`
- Added "Workflow 5: Hypothesis Testing with set-state" to `references/workflows.md`

## Test plan

- [ ] `debug-browser set-state Counter 0 42` updates a useState hook
- [ ] `debug-browser set-state TodoList 1 '["a","b"]'` sets array state
- [ ] `debug-browser set-state Foo 0 '{"key":"val"}'` sets object state
- [ ] Setting a non-state hook (e.g., useEffect index) returns an error
- [ ] Out-of-range hook index returns an error
- [ ] Non-existent component name returns an error
- [ ] State update triggers React re-render (verify with subsequent `hooks` call)

🤖 Generated with [Claude Code](https://claude.com/claude-code)