### PR TITLE
feat: add source location mapping and DOM-to-React inspect command

### DIFF
--- a/daemon/src/actions.ts
+++ b/daemon/src/actions.ts
@@ -28,6 +28,7 @@ import type {
   ComponentsCommand,
   HooksCommand,
   SetStateCommand,
+  SourceCommand,
   CookiesGetCommand,
   CookiesSetCommand,
   StorageGetCommand,
@@ -56,6 +57,12 @@ const HOOKS_SCRIPT = readFileSync(
 /** Cached set-state script content, loaded once at module init. */
 const SET_STATE_SCRIPT = readFileSync(
   fileURLToPath(new URL('./scripts/set-state.js', import.meta.url)),
+  'utf-8'
+);
+
+/** Cached source location script content, loaded once at module init. */
+const SOURCE_SCRIPT = readFileSync(
+  fileURLToPath(new URL('./scripts/get-source.js', import.meta.url)),
   'utf-8'
 );
 
@@ -127,6 +134,8 @@ export async function executeCommand(command: Command, browser: BrowserManager):
         return await handleHooks(command, browser);
       case 'set-state':
         return await handleSetState(command, browser);
+      case 'source':
+        return await handleSource(command, browser);
       case 'cookies_get':
         return await handleCookiesGet(command, browser);
       case 'cookies_set':
@@ -564,6 +573,23 @@ async function handleSetState(
 
   const result = await page.evaluate(
     `(${SET_STATE_SCRIPT})(${JSON.stringify(options)})`
+  );
+
+  return successResponse(command.id, result);
+}
+
+async function handleSource(
+  command: SourceCommand,
+  browser: BrowserManager
+): Promise<Response> {
+  const page = browser.getPage();
+
+  const options = {
+    component: command.component,
+  };
+
+  const result = await page.evaluate(
+    `(${SOURCE_SCRIPT})(${JSON.stringify(options)})`
   );
 
   return successResponse(command.id, result);

--- a/daemon/src/actions.ts
+++ b/daemon/src/actions.ts
@@ -29,6 +29,7 @@ import type {
   HooksCommand,
   SetStateCommand,
   SourceCommand,
+  InspectCommand,
   CookiesGetCommand,
   CookiesSetCommand,
   StorageGetCommand,
@@ -57,6 +58,12 @@ const HOOKS_SCRIPT = readFileSync(
 /** Cached set-state script content, loaded once at module init. */
 const SET_STATE_SCRIPT = readFileSync(
   fileURLToPath(new URL('./scripts/set-state.js', import.meta.url)),
+  'utf-8'
+);
+
+/** Cached inspect-element script content, loaded once at module init. */
+const INSPECT_SCRIPT = readFileSync(
+  fileURLToPath(new URL('./scripts/inspect-element.js', import.meta.url)),
   'utf-8'
 );
 
@@ -136,6 +143,8 @@ export async function executeCommand(command: Command, browser: BrowserManager):
         return await handleSetState(command, browser);
       case 'source':
         return await handleSource(command, browser);
+      case 'inspect':
+        return await handleInspect(command, browser);
       case 'cookies_get':
         return await handleCookiesGet(command, browser);
       case 'cookies_set':
@@ -590,6 +599,25 @@ async function handleSource(
 
   const result = await page.evaluate(
     `(${SOURCE_SCRIPT})(${JSON.stringify(options)})`
+  );
+
+  return successResponse(command.id, result);
+}
+
+async function handleInspect(
+  command: InspectCommand,
+  browser: BrowserManager
+): Promise<Response> {
+  const page = browser.getPage();
+
+  const options = {
+    selector: command.selector,
+    includeHooks: command.includeHooks ?? false,
+    depth: command.depth ?? 3,
+  };
+
+  const result = await page.evaluate(
+    `(${INSPECT_SCRIPT})(${JSON.stringify(options)})`
   );
 
   return successResponse(command.id, result);

--- a/daemon/src/protocol.ts
+++ b/daemon/src/protocol.ts
@@ -197,6 +197,11 @@ const setStateSchema = baseCommandSchema.extend({
   value: z.unknown(),
 });
 
+const sourceSchema = baseCommandSchema.extend({
+  action: z.literal('source'),
+  component: z.string().min(1),
+});
+
 const cookiesGetSchema = baseCommandSchema.extend({
   action: z.literal('cookies_get'),
   urls: z.array(z.string()).optional(),
@@ -283,6 +288,7 @@ const commandSchema = z.discriminatedUnion('action', [
   componentsSchema,
   hooksSchema,
   setStateSchema,
+  sourceSchema,
   cookiesGetSchema,
   cookiesSetSchema,
   cookiesClearSchema,

--- a/daemon/src/protocol.ts
+++ b/daemon/src/protocol.ts
@@ -202,6 +202,13 @@ const sourceSchema = baseCommandSchema.extend({
   component: z.string().min(1),
 });
 
+const inspectSchema = baseCommandSchema.extend({
+  action: z.literal('inspect'),
+  selector: z.string().min(1),
+  includeHooks: z.boolean().optional(),
+  depth: z.number().positive().optional(),
+});
+
 const cookiesGetSchema = baseCommandSchema.extend({
   action: z.literal('cookies_get'),
   urls: z.array(z.string()).optional(),
@@ -289,6 +296,7 @@ const commandSchema = z.discriminatedUnion('action', [
   hooksSchema,
   setStateSchema,
   sourceSchema,
+  inspectSchema,
   cookiesGetSchema,
   cookiesSetSchema,
   cookiesClearSchema,

--- a/daemon/src/scripts/get-component-tree.js
+++ b/daemon/src/scripts/get-component-tree.js
@@ -240,6 +240,22 @@
     return 'function';
   }
 
+  function getSourceLocation(fiber) {
+    // _debugSource is set by the React Babel/SWC transform in development mode
+    var source = fiber._debugSource;
+    if (source && source.fileName) {
+      var loc = { fileName: source.fileName };
+      if (typeof source.lineNumber === 'number') {
+        loc.lineNumber = source.lineNumber;
+      }
+      if (typeof source.columnNumber === 'number') {
+        loc.columnNumber = source.columnNumber;
+      }
+      return loc;
+    }
+    return null;
+  }
+
   function isUserComponent(fiber) {
     // Always include function/class components
     if (fiber.tag === FunctionComponent || fiber.tag === ClassComponent) return true;
@@ -270,6 +286,12 @@
           depth: depth,
           children: [],
         };
+
+        // Extract source location if available
+        var source = getSourceLocation(current);
+        if (source) {
+          node.source = source;
+        }
 
         // Extract props if requested
         if (includeProps) {

--- a/daemon/src/scripts/get-component-tree.js
+++ b/daemon/src/scripts/get-component-tree.js
@@ -241,7 +241,7 @@
   }
 
   function getSourceLocation(fiber) {
-    // _debugSource is set by the React Babel/SWC transform in development mode
+    // React <19: _debugSource is set by the Babel/SWC React transform
     var source = fiber._debugSource;
     if (source && source.fileName) {
       var loc = { fileName: source.fileName };
@@ -253,7 +253,55 @@
       }
       return loc;
     }
+
+    // React 19+: _debugStack is an Error with a stack trace
+    var debugStack = fiber._debugStack;
+    if (debugStack && debugStack.stack) {
+      return parseSourceFromStack(debugStack.stack);
+    }
+
     return null;
+  }
+
+  // Parse the last meaningful frame from a React _debugStack trace.
+  // Stack format: "Error: react-stack-top-frame\n    at jsxDEV (...)\n    at http://host/src/file.jsx:line:col"
+  // We want the last frame (the user's code), not the jsxDEV wrapper.
+  function parseSourceFromStack(stack) {
+    var lines = stack.split('\n');
+    // Find the last "at" frame — that's typically the user component call site
+    var userFrame = null;
+    for (var i = 1; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (line.indexOf('at ') !== 0) continue;
+      // Skip React internal frames (jsx-dev-runtime, react-dom, etc.)
+      if (line.indexOf('jsx-dev-runtime') !== -1) continue;
+      if (line.indexOf('jsx-runtime') !== -1) continue;
+      if (line.indexOf('react-dom') !== -1) continue;
+      if (line.indexOf('react.development') !== -1) continue;
+      if (line.indexOf('chunk-') !== -1) continue;
+      userFrame = line;
+    }
+    if (!userFrame) return null;
+
+    // Extract URL and line/col from patterns like:
+    //   "at App (http://localhost:5199/src/App.jsx:8:10)"
+    //   "at http://localhost:5199/src/main.jsx:7:116"
+    var match = userFrame.match(/(?:\(|at\s+)(https?:\/\/[^)]+)/);
+    if (!match) return null;
+
+    var fullUrl = match[1].replace(/\)$/, '');
+    // Parse "http://host:port/src/file.jsx:line:col"
+    var urlParts = fullUrl.match(/^https?:\/\/[^/]+(\/[^:]+?)(?::(\d+))?(?::(\d+))?$/);
+    if (!urlParts) return null;
+
+    var filePath = urlParts[1];
+    // Strip leading slash for cleaner display
+    if (filePath.charAt(0) === '/') filePath = filePath.substring(1);
+
+    var loc = { fileName: filePath };
+    if (urlParts[2]) loc.lineNumber = parseInt(urlParts[2], 10);
+    if (urlParts[3]) loc.columnNumber = parseInt(urlParts[3], 10);
+    return loc;
   }
 
   function isUserComponent(fiber) {

--- a/daemon/src/scripts/get-hooks.js
+++ b/daemon/src/scripts/get-hooks.js
@@ -371,6 +371,18 @@
   var resolvedName = getComponentName(targetFiber) || 'Anonymous';
   var resolvedType = getComponentType(targetFiber);
 
+  // Extract source location if available
+  var resolvedSource = null;
+  if (targetFiber._debugSource && targetFiber._debugSource.fileName) {
+    resolvedSource = { fileName: targetFiber._debugSource.fileName };
+    if (typeof targetFiber._debugSource.lineNumber === 'number') {
+      resolvedSource.lineNumber = targetFiber._debugSource.lineNumber;
+    }
+    if (typeof targetFiber._debugSource.columnNumber === 'number') {
+      resolvedSource.columnNumber = targetFiber._debugSource.columnNumber;
+    }
+  }
+
   // Get _debugHookTypes if available
   var debugHookTypes = targetFiber._debugHookTypes || null;
 
@@ -382,13 +394,15 @@
 
   // Class components don't have hook linked lists
   if (targetFiber.tag === ClassComponent) {
-    return {
+    var classResult = {
       component: resolvedName,
       type: resolvedType,
       hookCount: 0,
       hooks: [],
       classState: safeSerialize(targetFiber.memoizedState, 0, maxSerializeDepth, null),
     };
+    if (resolvedSource) classResult.source = resolvedSource;
+    return classResult;
   }
 
   while (hookNode && hookIndex < maxHooks) {
@@ -430,10 +444,12 @@
     filteredHooks.push(hooks[h]);
   }
 
-  return {
+  var result = {
     component: resolvedName,
     type: resolvedType,
     hookCount: filteredHooks.length,
     hooks: filteredHooks,
   };
+  if (resolvedSource) result.source = resolvedSource;
+  return result;
 })

--- a/daemon/src/scripts/get-hooks.js
+++ b/daemon/src/scripts/get-hooks.js
@@ -373,6 +373,7 @@
 
   // Extract source location if available
   var resolvedSource = null;
+  // React <19: _debugSource
   if (targetFiber._debugSource && targetFiber._debugSource.fileName) {
     resolvedSource = { fileName: targetFiber._debugSource.fileName };
     if (typeof targetFiber._debugSource.lineNumber === 'number') {
@@ -381,6 +382,37 @@
     if (typeof targetFiber._debugSource.columnNumber === 'number') {
       resolvedSource.columnNumber = targetFiber._debugSource.columnNumber;
     }
+  }
+  // React 19+: _debugStack
+  if (!resolvedSource && targetFiber._debugStack && targetFiber._debugStack.stack) {
+    resolvedSource = parseSourceFromStack(targetFiber._debugStack.stack);
+  }
+
+  function parseSourceFromStack(stack) {
+    var lines = stack.split('\n');
+    var userFrame = null;
+    for (var i = 1; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (line.indexOf('at ') !== 0) continue;
+      if (line.indexOf('jsx-dev-runtime') !== -1) continue;
+      if (line.indexOf('jsx-runtime') !== -1) continue;
+      if (line.indexOf('react-dom') !== -1) continue;
+      if (line.indexOf('react.development') !== -1) continue;
+      if (line.indexOf('chunk-') !== -1) continue;
+      userFrame = line;
+    }
+    if (!userFrame) return null;
+    var match = userFrame.match(/(?:\(|at\s+)(https?:\/\/[^)]+)/);
+    if (!match) return null;
+    var fullUrl = match[1].replace(/\)$/, '');
+    var urlParts = fullUrl.match(/^https?:\/\/[^/]+(\/[^:]+?)(?::(\d+))?(?::(\d+))?$/);
+    if (!urlParts) return null;
+    var filePath = urlParts[1];
+    if (filePath.charAt(0) === '/') filePath = filePath.substring(1);
+    var loc = { fileName: filePath };
+    if (urlParts[2]) loc.lineNumber = parseInt(urlParts[2], 10);
+    if (urlParts[3]) loc.columnNumber = parseInt(urlParts[3], 10);
+    return loc;
   }
 
   // Get _debugHookTypes if available

--- a/daemon/src/scripts/get-source.js
+++ b/daemon/src/scripts/get-source.js
@@ -68,6 +68,7 @@
   }
 
   function getSourceLocation(fiber) {
+    // React <19: _debugSource
     var source = fiber._debugSource;
     if (source && source.fileName) {
       var loc = { fileName: source.fileName };
@@ -79,7 +80,40 @@
       }
       return loc;
     }
+
+    // React 19+: _debugStack
+    if (fiber._debugStack && fiber._debugStack.stack) {
+      return parseSourceFromStack(fiber._debugStack.stack);
+    }
+
     return null;
+  }
+
+  function parseSourceFromStack(stack) {
+    var lines = stack.split('\n');
+    var userFrame = null;
+    for (var i = 1; i < lines.length; i++) {
+      var line = lines[i].trim();
+      if (line.indexOf('at ') !== 0) continue;
+      if (line.indexOf('jsx-dev-runtime') !== -1) continue;
+      if (line.indexOf('jsx-runtime') !== -1) continue;
+      if (line.indexOf('react-dom') !== -1) continue;
+      if (line.indexOf('react.development') !== -1) continue;
+      if (line.indexOf('chunk-') !== -1) continue;
+      userFrame = line;
+    }
+    if (!userFrame) return null;
+    var match = userFrame.match(/(?:\(|at\s+)(https?:\/\/[^)]+)/);
+    if (!match) return null;
+    var fullUrl = match[1].replace(/\)$/, '');
+    var urlParts = fullUrl.match(/^https?:\/\/[^/]+(\/[^:]+?)(?::(\d+))?(?::(\d+))?$/);
+    if (!urlParts) return null;
+    var filePath = urlParts[1];
+    if (filePath.charAt(0) === '/') filePath = filePath.substring(1);
+    var loc = { fileName: filePath };
+    if (urlParts[2]) loc.lineNumber = parseInt(urlParts[2], 10);
+    if (urlParts[3]) loc.columnNumber = parseInt(urlParts[3], 10);
+    return loc;
   }
 
   var matches = [];

--- a/daemon/src/scripts/get-source.js
+++ b/daemon/src/scripts/get-source.js
@@ -1,0 +1,116 @@
+// Source location lookup — resolves _debugSource for a React component.
+// Evaluated in page context via Playwright's page.evaluate().
+// Returns { component, source: { fileName, lineNumber, columnNumber } } or { error }.
+
+(function (options) {
+  var componentName = options && options.component;
+
+  if (!componentName) {
+    return { error: 'No component name provided' };
+  }
+
+  var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return { error: 'No React DevTools hook found' };
+  }
+
+  if (!hook._fiberRoots || hook._fiberRoots.size === 0) {
+    return { error: 'No React roots detected — page may not use React or has not rendered yet' };
+  }
+
+  // Fiber tag constants
+  var FunctionComponent = 0;
+  var ClassComponent = 1;
+  var ForwardRef = 11;
+  var MemoComponent = 14;
+  var SimpleMemoComponent = 15;
+
+  function getComponentName(fiber) {
+    if (!fiber.type) return null;
+    if (typeof fiber.type === 'string') return fiber.type;
+    if (fiber.type.displayName) return fiber.type.displayName;
+    if (fiber.type.name) return fiber.type.name;
+    if (fiber.type.render) {
+      return fiber.type.render.displayName || fiber.type.render.name || 'ForwardRef';
+    }
+    if (fiber.type.type) {
+      return fiber.type.type.displayName || fiber.type.type.name || 'Memo';
+    }
+    return 'Anonymous';
+  }
+
+  function isComponent(fiber) {
+    return (
+      fiber.tag === FunctionComponent ||
+      fiber.tag === ClassComponent ||
+      fiber.tag === ForwardRef ||
+      fiber.tag === MemoComponent ||
+      fiber.tag === SimpleMemoComponent
+    );
+  }
+
+  // Find ALL matching components (not just the first)
+  function findAllComponents(fiber, results) {
+    if (!fiber) return;
+    var current = fiber;
+    while (current) {
+      if (isComponent(current)) {
+        var name = getComponentName(current);
+        if (name && name.toLowerCase().indexOf(componentName.toLowerCase()) !== -1) {
+          results.push(current);
+        }
+      }
+      if (current.child) {
+        findAllComponents(current.child, results);
+      }
+      current = current.sibling;
+    }
+  }
+
+  function getSourceLocation(fiber) {
+    var source = fiber._debugSource;
+    if (source && source.fileName) {
+      var loc = { fileName: source.fileName };
+      if (typeof source.lineNumber === 'number') {
+        loc.lineNumber = source.lineNumber;
+      }
+      if (typeof source.columnNumber === 'number') {
+        loc.columnNumber = source.columnNumber;
+      }
+      return loc;
+    }
+    return null;
+  }
+
+  var matches = [];
+
+  hook._fiberRoots.forEach(function (fiberRootSet) {
+    fiberRootSet.forEach(function (fiberRoot) {
+      if (fiberRoot.current) {
+        findAllComponents(fiberRoot.current, matches);
+      }
+    });
+  });
+
+  if (matches.length === 0) {
+    return { error: 'Component not found: ' + componentName };
+  }
+
+  // Deduplicate by component name + source location
+  var seen = {};
+  var results = [];
+  for (var i = 0; i < matches.length; i++) {
+    var name = getComponentName(matches[i]) || 'Anonymous';
+    var source = getSourceLocation(matches[i]);
+    var key = name + '|' + (source ? source.fileName + ':' + (source.lineNumber || '') : 'unknown');
+    if (!seen[key]) {
+      seen[key] = true;
+      results.push({
+        component: name,
+        source: source,
+      });
+    }
+  }
+
+  return { matches: results };
+})

--- a/daemon/src/scripts/inspect-element.js
+++ b/daemon/src/scripts/inspect-element.js
@@ -1,0 +1,265 @@
+// DOM element to React component reverse lookup.
+// Given a CSS selector, finds the owning React component via __reactFiber$ keys.
+// Evaluated in page context via Playwright's page.evaluate().
+// Returns { component, type, source, owners, hooks } or { error }.
+
+(function (options) {
+  var selector = options && options.selector;
+  var includeHooks = !!(options && options.includeHooks);
+  var maxSerializeDepth = (options && options.depth) || 3;
+
+  if (!selector) {
+    return { error: 'No selector provided' };
+  }
+
+  var hook = window.__REACT_DEVTOOLS_GLOBAL_HOOK__;
+  if (!hook) {
+    return { error: 'No React DevTools hook found' };
+  }
+
+  // Find the DOM element
+  var element = document.querySelector(selector);
+  if (!element) {
+    return { error: 'Element not found: ' + selector };
+  }
+
+  // Find the React fiber key on the element
+  var fiberKey = null;
+  var keys = Object.keys(element);
+  for (var i = 0; i < keys.length; i++) {
+    if (keys[i].indexOf('__reactFiber$') === 0 || keys[i].indexOf('__reactInternalInstance$') === 0) {
+      fiberKey = keys[i];
+      break;
+    }
+  }
+
+  if (!fiberKey) {
+    return { error: 'No React fiber found on element matching: ' + selector + ' — element may not be managed by React' };
+  }
+
+  var fiber = element[fiberKey];
+  if (!fiber) {
+    return { error: 'React fiber is null on element' };
+  }
+
+  // Fiber tag constants
+  var FunctionComponent = 0;
+  var ClassComponent = 1;
+  var ForwardRef = 11;
+  var MemoComponent = 14;
+  var SimpleMemoComponent = 15;
+
+  function isUserComponent(f) {
+    return (
+      f.tag === FunctionComponent ||
+      f.tag === ClassComponent ||
+      f.tag === ForwardRef ||
+      f.tag === MemoComponent ||
+      f.tag === SimpleMemoComponent
+    );
+  }
+
+  function getComponentName(f) {
+    if (!f.type) return null;
+    if (typeof f.type === 'string') return f.type;
+    if (f.type.displayName) return f.type.displayName;
+    if (f.type.name) return f.type.name;
+    if (f.type.render) {
+      return f.type.render.displayName || f.type.render.name || 'ForwardRef';
+    }
+    if (f.type.type) {
+      return f.type.type.displayName || f.type.type.name || 'Memo';
+    }
+    return 'Anonymous';
+  }
+
+  function getComponentType(f) {
+    if (f.tag === ClassComponent) return 'class';
+    if (f.tag === ForwardRef) return 'forward-ref';
+    if (f.tag === MemoComponent || f.tag === SimpleMemoComponent) return 'memo';
+    return 'function';
+  }
+
+  function getSourceLocation(f) {
+    var source = f._debugSource;
+    if (source && source.fileName) {
+      var loc = { fileName: source.fileName };
+      if (typeof source.lineNumber === 'number') {
+        loc.lineNumber = source.lineNumber;
+      }
+      if (typeof source.columnNumber === 'number') {
+        loc.columnNumber = source.columnNumber;
+      }
+      return loc;
+    }
+    return null;
+  }
+
+  // --- Safe serialization helper ---
+  function safeSerialize(value, currentDepth, maxDepth, seen) {
+    if (currentDepth > maxDepth) return '[Truncated]';
+    if (value === null) return null;
+    if (value === undefined) return '[undefined]';
+
+    var type = typeof value;
+    if (type === 'string') {
+      return value.length > 200 ? value.slice(0, 200) + '...' : value;
+    }
+    if (type === 'number' || type === 'boolean') return value;
+    if (type === 'function') return '[Function]';
+    if (type === 'symbol') return '[Symbol: ' + String(value) + ']';
+    if (type === 'bigint') return value.toString() + 'n';
+
+    if (value instanceof Element) return '[Element: ' + value.tagName.toLowerCase() + ']';
+    if (value instanceof Node) return '[Node: ' + value.nodeName + ']';
+
+    if (value && value.$$typeof) {
+      var elemType = value.type;
+      var elemName = 'unknown';
+      if (typeof elemType === 'string') elemName = elemType;
+      else if (typeof elemType === 'function') elemName = elemType.displayName || elemType.name || 'Component';
+      else if (elemType && typeof elemType === 'object') elemName = elemType.displayName || elemType.name || 'Component';
+      return '[ReactElement: ' + elemName + ']';
+    }
+
+    if (!seen) seen = [];
+    for (var s = 0; s < seen.length; s++) {
+      if (seen[s] === value) return '[Circular]';
+    }
+    seen = seen.concat([value]);
+
+    if (Array.isArray(value)) {
+      if (value.length === 0) return [];
+      if (currentDepth === maxDepth) return '[Array(' + value.length + ')]';
+      var arr = [];
+      for (var ai = 0; ai < value.length; ai++) {
+        arr.push(safeSerialize(value[ai], currentDepth + 1, maxDepth, seen));
+      }
+      return arr;
+    }
+
+    if (type === 'object') {
+      var objKeys = Object.keys(value);
+      if (objKeys.length === 0) return {};
+      if (currentDepth === maxDepth) return '[Object(' + objKeys.length + ' keys)]';
+      var obj = {};
+      for (var k = 0; k < objKeys.length; k++) {
+        try {
+          obj[objKeys[k]] = safeSerialize(value[objKeys[k]], currentDepth + 1, maxDepth, seen);
+        } catch (e) {
+          obj[objKeys[k]] = '[Error]';
+        }
+      }
+      return obj;
+    }
+
+    return String(value);
+  }
+
+  // Walk up the fiber tree to find the nearest user component
+  var current = fiber;
+  var nearestComponent = null;
+
+  while (current) {
+    if (isUserComponent(current)) {
+      nearestComponent = current;
+      break;
+    }
+    current = current.return;
+  }
+
+  if (!nearestComponent) {
+    return { error: 'No React component found owning element: ' + selector };
+  }
+
+  var result = {
+    component: getComponentName(nearestComponent) || 'Anonymous',
+    type: getComponentType(nearestComponent),
+    source: getSourceLocation(nearestComponent),
+  };
+
+  // Build owner chain by walking up from the component
+  var owners = [];
+  var ownerFiber = nearestComponent.return;
+  var maxOwners = 10;
+  while (ownerFiber && owners.length < maxOwners) {
+    if (isUserComponent(ownerFiber)) {
+      var ownerInfo = {
+        component: getComponentName(ownerFiber) || 'Anonymous',
+        type: getComponentType(ownerFiber),
+        source: getSourceLocation(ownerFiber),
+      };
+      owners.push(ownerInfo);
+    }
+    ownerFiber = ownerFiber.return;
+  }
+  result.owners = owners;
+
+  // Optionally extract hooks summary
+  if (includeHooks && nearestComponent.tag !== ClassComponent) {
+    var hooks = [];
+    var hookNode = nearestComponent.memoizedState;
+    var hookIndex = 0;
+    var maxHooks = 50;
+    var debugHookTypes = nearestComponent._debugHookTypes || null;
+
+    // Known hook name mappings
+    var DEBUG_TYPE_MAP = {
+      'useState': 'state', 'useReducer': 'reducer',
+      'useEffect': 'effect', 'useLayoutEffect': 'layout-effect',
+      'useInsertionEffect': 'insertion-effect', 'useRef': 'ref',
+      'useMemo': 'memo', 'useCallback': 'callback',
+      'useContext': 'context', 'useDebugValue': 'debug-value',
+      'useTransition': 'transition', 'useDeferredValue': 'deferred-value',
+      'useId': 'id', 'useSyncExternalStore': 'sync-external-store',
+      'useImperativeHandle': 'imperative-handle'
+    };
+
+    while (hookNode && hookIndex < maxHooks) {
+      var hookType = 'unknown';
+
+      // Use _debugHookTypes if available
+      if (debugHookTypes && hookIndex < debugHookTypes.length) {
+        var debugType = debugHookTypes[hookIndex];
+        hookType = DEBUG_TYPE_MAP[debugType] || debugType.replace(/^use/, '').toLowerCase() || 'unknown';
+      } else {
+        var ms = hookNode.memoizedState;
+        if (typeof ms === 'string' && /^:r[0-9a-z]+:$/.test(ms)) {
+          hookType = 'id';
+        } else if (hookNode.queue !== null && hookNode.queue !== undefined) {
+          hookType = 'state';
+        } else if (ms && typeof ms === 'object' && typeof ms.create === 'function' && 'tag' in ms) {
+          hookType = 'effect';
+        } else if (ms && typeof ms === 'object' && !Array.isArray(ms) && hookNode.queue === null) {
+          var msKeys = Object.keys(ms);
+          if (msKeys.length === 1 && msKeys[0] === 'current') hookType = 'ref';
+        } else if (Array.isArray(ms) && ms.length === 2 && hookNode.queue === null) {
+          hookType = typeof ms[0] === 'function' ? 'callback' : 'memo';
+        }
+      }
+
+      var hookData = { index: hookIndex, type: hookType };
+
+      // Extract value for state/reducer hooks
+      if (hookType === 'state' || hookType === 'reducer') {
+        hookData.value = safeSerialize(hookNode.memoizedState, 0, maxSerializeDepth, null);
+      }
+
+      hooks.push(hookData);
+      hookNode = hookNode.next;
+      hookIndex++;
+    }
+
+    result.hookCount = hooks.length;
+    result.hooks = hooks;
+  }
+
+  // Include DOM element info
+  result.element = {
+    tagName: element.tagName.toLowerCase(),
+    id: element.id || null,
+    className: element.className || null,
+  };
+
+  return result;
+})

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -189,6 +189,11 @@ export interface SetStateCommand extends BaseCommand {
   value: unknown;
 }
 
+export interface SourceCommand extends BaseCommand {
+  action: 'source';
+  component: string;
+}
+
 export interface CookiesGetCommand extends BaseCommand {
   action: 'cookies_get';
   urls?: string[];
@@ -273,6 +278,7 @@ export type Command =
   | ComponentsCommand
   | HooksCommand
   | SetStateCommand
+  | SourceCommand
   | CookiesGetCommand
   | CookiesSetCommand
   | CookiesClearCommand

--- a/daemon/src/types.ts
+++ b/daemon/src/types.ts
@@ -194,6 +194,13 @@ export interface SourceCommand extends BaseCommand {
   component: string;
 }
 
+export interface InspectCommand extends BaseCommand {
+  action: 'inspect';
+  selector: string;
+  includeHooks?: boolean;
+  depth?: number;
+}
+
 export interface CookiesGetCommand extends BaseCommand {
   action: 'cookies_get';
   urls?: string[];
@@ -279,6 +286,7 @@ export type Command =
   | HooksCommand
   | SetStateCommand
   | SourceCommand
+  | InspectCommand
   | CookiesGetCommand
   | CookiesSetCommand
   | CookiesClearCommand

--- a/skill/SKILL.md
+++ b/skill/SKILL.md
@@ -4,8 +4,9 @@ description: >
   Debug React applications via headless browser with rich introspection.
   Trigger when the user asks to: debug React app, inspect React components,
   check component state, view hook values, set React state, modify hook state,
-  capture console errors, debug React rendering, inspect fiber tree,
-  examine React props, trace React re-renders, or diagnose React application issues.
+  find component source, locate component file, capture console errors,
+  debug React rendering, inspect fiber tree, examine React props,
+  trace React re-renders, or diagnose React application issues.
 ---
 
 # debug-browser
@@ -152,6 +153,27 @@ debug-browser console errors
 ```
 
 Only `useState` and `useReducer` hooks can be set. Attempting to set an effect, ref, or memo hook returns an error. The state update triggers a normal React re-render, so all derived state, effects, and child components update as expected.
+
+### Locate Component Source Files
+
+Source file locations appear automatically in `components` and `hooks` output when the app is running in development mode (Vite, webpack dev, Next.js dev, etc.):
+
+```
+LoginPage (function) src/pages/LoginPage.tsx:15
+```
+
+```
+Hooks for LoginPage (function, src/pages/LoginPage.tsx:15, 5 hooks):
+```
+
+Use the dedicated `source` command for a quick lookup without the full tree or hook details:
+
+```bash
+debug-browser source LoginPage
+# LoginPage -> src/pages/LoginPage.tsx:15
+```
+
+This maps directly to `file:line` format — use it to jump from inspection to editing the right file. Source info depends on React's `_debugSource` transform, which is included in development builds but stripped in production.
 
 ### Check Console Output
 

--- a/skill/references/commands.md
+++ b/skill/references/commands.md
@@ -9,6 +9,7 @@
 | `components` | List React component tree | `--depth`, `--component`, `--no-props`, `--no-state`, `--compact` |
 | `hooks <component>` | Inspect hooks for a named component | `--depth`, `--compact` |
 | `set-state <component> <index> <value>` | Set a useState/useReducer hook's value | |
+| `source <component>` | Look up source file location for a component | |
 | `console logs` | Show collected console.log messages | |
 | `console errors` | Show collected errors and exceptions | |
 | `console clear` | Clear the console inbox | |
@@ -163,6 +164,7 @@ debug-browser components --compact
 - On pages without React, returns "No React components detected" (text) or an object with `componentCount: 0` (JSON).
 - The `--component` filter preserves ancestor components in the tree, showing the full path from root to each matched component.
 - Combine `--no-props --no-state` first to get a structural overview, then drill into specific components.
+- Source file locations (`file:line`) are shown for each component when available (development builds).
 
 ---
 
@@ -215,6 +217,7 @@ debug-browser hooks Counter --compact
 - For class components, returns `classState` instead of hooks array.
 - Each hook has a stable index (`[0]`, `[1]`, etc.) for tracking values across repeated inspections.
 - If multiple components match the name, the first match is inspected.
+- Source file location (`file:line`) is shown in the header when available (development builds).
 
 ---
 
@@ -272,6 +275,47 @@ debug-browser set-state Form 0 null
 - The state update triggers a normal React re-render — effects, derived state, and child components update accordingly.
 - Uses React DevTools' `overrideHookState` API when available, with a fallback to the hook's dispatch function.
 - Use `hooks <component>` first to identify the correct hook index.
+
+---
+
+## source
+
+**Syntax:**
+
+```
+debug-browser source <component>
+```
+
+**Purpose:** Look up the source file and line number where a React component is defined. Enables going directly from component inspection to editing the source file.
+
+**Arguments:**
+
+| Argument | Type | Required | Description |
+|----------|------|----------|-------------|
+| `component` | `string` | yes | Component name (same substring match as `hooks`). |
+
+**Output:**
+
+- **text:** One line per unique match. Example:
+  ```
+  LoginPage -> src/pages/LoginPage.tsx:15
+  Card -> src/components/ui/card.tsx:8
+  ```
+- **json:** `{ "success": true, "data": { "matches": [{ "component": "LoginPage", "source": { "fileName": "src/pages/LoginPage.tsx", "lineNumber": 15 } }] } }`
+
+**Example:**
+
+```bash
+debug-browser source LoginPage
+debug-browser source Card
+debug-browser source Button --format json
+```
+
+**Notes:**
+- Source locations are also shown inline in `components` and `hooks` output — this command is for quick lookups without the full tree.
+- Depends on React's `_debugSource` fiber property, which is set by the Babel/SWC React transform in development mode.
+- Production builds strip `_debugSource`, so this returns "(no source info)" for production bundles.
+- If multiple components match the name, all unique source locations are listed (deduplicated by name + file + line).
 
 ---
 

--- a/skill/references/workflows.md
+++ b/skill/references/workflows.md
@@ -33,6 +33,11 @@ debug-browser hooks UserProfile
 #    Compare useState values before/after
 #    If unchanged: the event handler isn't updating state
 #    If changed but UI wrong: check for stale closure or missing dep
+
+# 8. Jump to the source file to fix the issue
+debug-browser source UserProfile
+#    UserProfile -> src/components/UserProfile.tsx:12
+#    Now open that file:line to edit the component
 ```
 
 ## Workflow 2: Console Errors on Page Load

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -155,6 +155,22 @@ pub fn source(component: &str) -> Value {
     })
 }
 
+/// Reverse-lookup: find the React component owning a DOM element.
+pub fn inspect(selector: &str, include_hooks: bool, depth: Option<u32>) -> Value {
+    let mut cmd = json!({
+        "id": gen_id(),
+        "action": "inspect",
+        "selector": selector,
+    });
+    if include_hooks {
+        cmd["includeHooks"] = json!(true);
+    }
+    if let Some(d) = depth {
+        cmd["depth"] = json!(d);
+    }
+    cmd
+}
+
 /// Detect whether React is present on the current page.
 pub fn react_detect() -> Value {
     json!({

--- a/src/commands.rs
+++ b/src/commands.rs
@@ -146,6 +146,15 @@ pub fn set_state(component: &str, hook_index: u32, value: Value) -> Value {
     })
 }
 
+/// Look up the source file location for a React component.
+pub fn source(component: &str) -> Value {
+    json!({
+        "id": gen_id(),
+        "action": "source",
+        "component": component,
+    })
+}
+
 /// Detect whether React is present on the current page.
 pub fn react_detect() -> Value {
     json!({

--- a/src/main.rs
+++ b/src/main.rs
@@ -105,6 +105,17 @@ enum Commands {
         /// Component name (substring match)
         component: String,
     },
+    /// Reverse-lookup: find the React component owning a DOM element
+    Inspect {
+        /// CSS selector for the DOM element
+        selector: String,
+        /// Include hooks summary in output
+        #[arg(long)]
+        hooks: bool,
+        /// Max serialization depth for hook values (default: 3)
+        #[arg(long)]
+        depth: Option<u32>,
+    },
     /// Manage console logs/errors inbox
     Console {
         #[command(subcommand)]
@@ -263,6 +274,7 @@ fn build_command(command: &Commands) -> serde_json::Value {
             commands::set_state(component, *hook_index, parsed)
         }
         Commands::Source { component } => commands::source(component),
+        Commands::Inspect { selector, hooks, depth } => commands::inspect(selector, *hooks, *depth),
         Commands::Console { action } => match action {
             ConsoleAction::Logs => commands::console_logs(),
             ConsoleAction::Errors => commands::console_errors(),
@@ -723,6 +735,58 @@ fn print_source(resp: &Response) {
                     println!("{} -> {}", name, source);
                 } else {
                     println!("{} -> (no source info — production build?)", name);
+                }
+            }
+        }
+    } else {
+        println!("No data returned.");
+    }
+}
+
+/// Print inspect (DOM-to-React reverse lookup) results.
+fn print_inspect(resp: &Response) {
+    if let Some(ref data) = resp.data {
+        if let Some(err) = data.get("error").and_then(|v| v.as_str()) {
+            eprintln!("Error: {}", err);
+            return;
+        }
+
+        let component = data.get("component").and_then(|v| v.as_str()).unwrap_or("?");
+        let comp_type = data.get("type").and_then(|v| v.as_str()).unwrap_or("?");
+        let source_str = data
+            .get("source")
+            .and_then(format_source)
+            .map(|s| format!(" {}", s))
+            .unwrap_or_default();
+
+        println!("{} ({}){}", component, comp_type, source_str);
+
+        // Print owner chain
+        if let Some(owners) = data.get("owners").and_then(|v| v.as_array()) {
+            for (i, owner) in owners.iter().enumerate() {
+                let name = owner.get("component").and_then(|v| v.as_str()).unwrap_or("?");
+                let otype = owner.get("type").and_then(|v| v.as_str()).unwrap_or("?");
+                let osource = owner
+                    .get("source")
+                    .and_then(format_source)
+                    .map(|s| format!(" {}", s))
+                    .unwrap_or_default();
+                let prefix = if i == 0 { "  owned by: " } else { "         -> " };
+                println!("{}{} ({}){}", prefix, name, otype, osource);
+            }
+        }
+
+        // Print hooks if included
+        if let Some(hooks) = data.get("hooks").and_then(|v| v.as_array()) {
+            let hook_count = data.get("hookCount").and_then(|v| v.as_u64()).unwrap_or(0);
+            println!("  hooks ({}):", hook_count);
+            for hook in hooks {
+                let index = hook.get("index").and_then(|v| v.as_u64()).unwrap_or(0);
+                let hook_type = hook.get("type").and_then(|v| v.as_str()).unwrap_or("unknown");
+                if let Some(value) = hook.get("value") {
+                    println!("    [{}] {}: {}", index, hook_type, compact_json(value));
+                } else {
+                    println!("    [{}] {}", index, hook_type);
                 }
             }
         }
@@ -1252,6 +1316,7 @@ fn main() -> Result<()> {
                     },
                     Commands::SetState { .. } => print_set_state(&resp),
                     Commands::Source { .. } => print_source(&resp),
+                    Commands::Inspect { .. } => print_inspect(&resp),
                     Commands::Click { .. } | Commands::Type { .. } => print_action_confirmation(&resp),
                     Commands::Close => print_action_confirmation(&resp),
                 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -100,6 +100,11 @@ enum Commands {
         /// New value (JSON)
         value: String,
     },
+    /// Look up source file location for a React component
+    Source {
+        /// Component name (substring match)
+        component: String,
+    },
     /// Manage console logs/errors inbox
     Console {
         #[command(subcommand)]
@@ -257,6 +262,7 @@ fn build_command(command: &Commands) -> serde_json::Value {
                 .unwrap_or_else(|_| serde_json::Value::String(value.clone()));
             commands::set_state(component, *hook_index, parsed)
         }
+        Commands::Source { component } => commands::source(component),
         Commands::Console { action } => match action {
             ConsoleAction::Logs => commands::console_logs(),
             ConsoleAction::Errors => commands::console_errors(),
@@ -398,6 +404,10 @@ fn format_tree_node(
     output.push_str(" (");
     output.push_str(comp_type);
     output.push(')');
+    if let Some(source) = node.get("source").and_then(format_source) {
+        output.push(' ');
+        output.push_str(&source);
+    }
     if let Some(k) = key {
         output.push_str(" key=\"");
         output.push_str(k);
@@ -511,20 +521,25 @@ fn print_hooks(resp: &Response) {
             .get("hookCount")
             .and_then(|v| v.as_u64())
             .unwrap_or(0);
+        let source_str = data
+            .get("source")
+            .and_then(format_source)
+            .map(|s| format!(", {}", s))
+            .unwrap_or_default();
 
         // Handle class components with classState
         if let Some(class_state) = data.get("classState") {
             println!(
-                "Hooks for {} ({}, class component):",
-                component, comp_type
+                "Hooks for {} ({}{}, class component):",
+                component, comp_type, source_str
             );
             println!("  classState: {}", compact_json(class_state));
             return;
         }
 
         println!(
-            "Hooks for {} ({}, {} hooks):",
-            component, comp_type, hook_count
+            "Hooks for {} ({}{}, {} hooks):",
+            component, comp_type, source_str, hook_count
         );
 
         if let Some(hooks) = data.get("hooks").and_then(|v| v.as_array()) {
@@ -674,6 +689,43 @@ fn print_set_state(resp: &Response) {
         let component = data.get("component").and_then(|v| v.as_str()).unwrap_or("?");
         let hook_index = data.get("hookIndex").and_then(|v| v.as_u64()).unwrap_or(0);
         println!("State updated: {} hook [{}]", component, hook_index);
+    } else {
+        println!("No data returned.");
+    }
+}
+
+/// Format a source location from JSON data as "file:line" or "file:line:col".
+fn format_source(source: &serde_json::Value) -> Option<String> {
+    let file = source.get("fileName").and_then(|v| v.as_str())?;
+    let line = source.get("lineNumber").and_then(|v| v.as_u64());
+    match line {
+        Some(l) => Some(format!("{}:{}", file, l)),
+        None => Some(file.to_string()),
+    }
+}
+
+/// Print source location lookup results.
+fn print_source(resp: &Response) {
+    if let Some(ref data) = resp.data {
+        if let Some(err) = data.get("error").and_then(|v| v.as_str()) {
+            eprintln!("Error: {}", err);
+            return;
+        }
+
+        if let Some(matches) = data.get("matches").and_then(|v| v.as_array()) {
+            if matches.is_empty() {
+                println!("No source location available.");
+                return;
+            }
+            for m in matches {
+                let name = m.get("component").and_then(|v| v.as_str()).unwrap_or("?");
+                if let Some(source) = m.get("source").and_then(format_source) {
+                    println!("{} -> {}", name, source);
+                } else {
+                    println!("{} -> (no source info — production build?)", name);
+                }
+            }
+        }
     } else {
         println!("No data returned.");
     }
@@ -1199,6 +1251,7 @@ fn main() -> Result<()> {
                         StateAction::Load => print_response(&resp, &cli.format),
                     },
                     Commands::SetState { .. } => print_set_state(&resp),
+                    Commands::Source { .. } => print_source(&resp),
                     Commands::Click { .. } | Commands::Type { .. } => print_action_confirmation(&resp),
                     Commands::Close => print_action_confirmation(&resp),
                 }


### PR DESCRIPTION
## Summary

Closes #2, closes #3.

### Source location mapping (#2)

Shows source file and line number (`file:line`) for React components across all output:

- **`components` output** — each node includes `file:line`:
  ```
  LoginPage (function) src/pages/LoginPage.tsx:15
  ```
- **`hooks` output** — source in header
- **`source` command** — dedicated quick lookup

Extracts `_debugSource` (React <19) and `_debugStack` (React 19+) from fiber nodes.

### DOM-to-React reverse lookup (#3)

New `inspect` command: given a CSS selector, finds the owning React component via `__reactFiber$` keys:

```bash
debug-browser inspect "button.submit"
# Button (function) src/components/ui/button.tsx:12
#   owned by: LoginPage (function) src/pages/LoginPage.tsx:42

debug-browser inspect "#username" --hooks
# Input (function) src/components/ui/input.tsx:8
#   owned by: LoginPage (function) src/pages/LoginPage.tsx:35
#   hooks (2):
#     [0] state: ""
#     [1] ref
```

## Test plan

- [ ] `components` output shows `file:line` for each component (dev build)
- [ ] `source <component>` returns file:line for matching components
- [ ] `inspect <selector>` returns owning React component with owner chain
- [ ] `inspect <selector> --hooks` includes hooks summary
- [ ] Non-React elements return clear error message
- [ ] Production builds show no source info without errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)